### PR TITLE
Update the documentation of diff() in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ var c2 = new Counter({b: 1})
 
 c1.diff(c2) // {a: 1, b: 1}
 
-var c3 = new Counter({a:1, b:1})
+var c3 = new Counter({a: 1, b: 1})
 
-c3.diff(c2) // {a:1, b:0}
+c3.diff(c2) // {a: 1, b: 0}
 ```
 
 You can also use "references": if an item has qty `X`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ And create a diff between counters:
 var c1 = new Counter({a: 1})
 var c2 = new Counter({b: 1})
 
-c1.diff(c2) // {a: 1, b: 0}
+c1.diff(c2) // {a: 1, b: 1}
+
+var c3 = new Counter({a:1, b:1})
+
+c3.diff(c2) // {a:1, b:0}
 ```
 
 You can also use "references": if an item has qty `X`


### PR DESCRIPTION
The diff() should return the difference of the counters. But in the example given {a:1, b:0} even though there were no occurrence of b in counter c1
